### PR TITLE
Ignore unknown properties from SlackResponse

### DIFF
--- a/src/main/java/org/graylog2/alarmcallbacks/slack/SlackClient.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/slack/SlackClient.java
@@ -243,6 +243,7 @@ public class SlackClient {
         }
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class SlackResponse {
         @JsonProperty
         public boolean ok;


### PR DESCRIPTION
Ignore unknown properties (like 'message') from SlackResponse