### PR TITLE
Update SlackClient.java

### DIFF
--- a/src/main/java/org/graylog2/alarmcallbacks/slack/SlackClient.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/slack/SlackClient.java
@@ -160,7 +160,8 @@ public class SlackClient {
 
         if (addAttachment) {
             final AlertCondition alertCondition = checkResult.getTriggeredCondition();
-            final int searchHits = firstNonNull(alertCondition.getSearchHits(), Collections.emptyList()).size();
+            final int matchingMessagesSize = checkResult.getMatchingMessages().size();
+            final int searchHits = Math.min(alertCondition.getBacklog(), matchingMessagesSize);
             final ImmutableList.Builder<AttachmentField> fields = ImmutableList.<AttachmentField>builder()
                     .add(new AttachmentField("Backlog", String.valueOf(alertCondition.getBacklog()), true))
                     .add(new AttachmentField("Search hits", String.valueOf(searchHits), true))


### PR DESCRIPTION
getSearchHits() no longer exists used similar logic from the PagerDuty plugin